### PR TITLE
fix(core): Modifying what you were collecting even though you didn't have a WebSocket setup

### DIFF
--- a/core/src/main/java/com/apighost/agent/collector/WebSocketCollector.java
+++ b/core/src/main/java/com/apighost/agent/collector/WebSocketCollector.java
@@ -59,7 +59,11 @@ public class WebSocketCollector implements Collector {
             brokerDestinationPrefix = configInfo.brokerPrefix;
             stompEndpoint = configInfo.stompEndpoint;
 
-            addConnectionEndpoints();
+            if (!appDestinationPrefix.isEmpty() &&
+                !brokerDestinationPrefix.isEmpty() &&
+                !stompEndpoint.isEmpty()) {
+                addConnectionEndpoints();
+            }
 
             for (ClassInfo classInfo : scanResult.getClassesWithAnnotation(
                 "org.springframework.stereotype.Controller")) {

--- a/core/src/main/java/com/apighost/agent/collector/util/WebSocketAnalyzerUtil.java
+++ b/core/src/main/java/com/apighost/agent/collector/util/WebSocketAnalyzerUtil.java
@@ -37,7 +37,7 @@ public class WebSocketAnalyzerUtil {
         }
 
         // default fallback
-        return new WebSocketConfigInfo("/app", "/topic", "/ws");
+        return new WebSocketConfigInfo("","","");
     }
 
     private static WebSocketConfigInfo extractConfigFromJavaFile(File javaFile) throws IOException {
@@ -46,9 +46,9 @@ public class WebSocketAnalyzerUtil {
             .orElseThrow(() -> new RuntimeException(
                 "Failed to parse Java file: " + javaFile.getAbsolutePath()));
 
-        String appPrefix = "/app";
-        String brokerPrefix = "/topic";
-        String stompEndpoint = "/ws";
+        String appPrefix = "";
+        String brokerPrefix = "";
+        String stompEndpoint = "";
 
         for (MethodDeclaration method : cu.findAll(MethodDeclaration.class)) {
             if (method.getNameAsString().equals("configureMessageBroker")) {


### PR DESCRIPTION
<!--  
Thank you for contributing to the API GHOST project.  
This document provides guidelines to ensure smooth collaboration and maintain high code quality.  
-->

<!--
PR Title Format Guideline

Use the following format for your PR title:

    type(scope): concise description

Examples:
    feat(api): add scenario execution support
    fix(parser): resolve YAML parsing error
    docs(readme): update CLI usage instructions

Available types:
    feat:     Add a new feature
    fix:      Fix a bug
    build:    Modify build system or external dependencies
    chore:    Modify configuration files unrelated to source or test files (e.g., .gitignore, .editorconfig)
    ci:       Update CI configuration files and scripts
    test:     Add or update tests
    docs:     Update documentation (e.g., README)
    refactor: Code changes that neither fix a bug nor add a feature
    style:    modify CSS styles
-->


### Description

- Improve the behavior of WebSocketAnalyzerUtil.analyze() to avoid setting default WebSocket configuration values when source parsing fails.
- This allows conditional logic (e.g., skipping addConnectionEndpoints()) based on the presence of valid configuration data.
- Changed fallback return in WebSocketAnalyzerUtil.analyze() to return empty strings ("") instead of default values (/app, /topic, /ws) when analysis fails.
### Testing

- Verified with a sample Spring project both with and without a @EnableWebSocketMessageBroker configuration class.

### Pre-Submission Checklist

- [x] Have you completed code style (convention) checks locally?
- [x] Have you passed the CI tests in your local environment?

