### PR TITLE
fix(core): websocket-subscribe-target

### DIFF
--- a/core/src/main/java/com/apighost/agent/collector/util/EndpointUtil.java
+++ b/core/src/main/java/com/apighost/agent/collector/util/EndpointUtil.java
@@ -256,20 +256,22 @@ public class EndpointUtil {
      * Extracts string array values from annotation attributes.
      *
      * @param annotationInfo the annotation metadata
-     * @param key            the attribute name to extract
+     * @param keys           the attribute name to extract
      * @return list of string values or empty list if not found
      */
-    public static List<String> extractStringArray(AnnotationInfo annotationInfo, String key) {
+    public static List<String> extractStringArray(AnnotationInfo annotationInfo, String... keys) {
         if (annotationInfo == null) {
             return Collections.emptyList();
         }
 
-        Object value = annotationInfo.getParameterValues().getValue(key);
-        if (value instanceof String) {
-            return Collections.singletonList((String) value);
-        } else if (value instanceof String[]) {
-            String[] array = (String[]) value;
-            return array.length > 0 ? Arrays.asList(array) : Collections.emptyList();
+        for (String key : keys) {
+            Object value = annotationInfo.getParameterValues().getValue(key);
+            if (value instanceof String) {
+                return Collections.singletonList((String) value);
+            } else if (value instanceof String[]) {
+                String[] array = (String[]) value;
+                return array.length > 0 ? Arrays.asList(array) : Collections.emptyList();
+            }
         }
 
         return Collections.emptyList();


### PR DESCRIPTION
<!--  
Thank you for contributing to the API GHOST project.  
This document provides guidelines to ensure smooth collaboration and maintain high code quality.  
-->

<!--
PR Title Format Guideline

Use the following format for your PR title:

    type(scope): concise description

Examples:
    feat(api): add scenario execution support
    fix(parser): resolve YAML parsing error
    docs(readme): update CLI usage instructions

Available types:
    feat:     Add a new feature
    fix:      Fix a bug
    build:    Modify build system or external dependencies
    chore:    Modify configuration files unrelated to source or test files (e.g., .gitignore, .editorconfig)
    ci:       Update CI configuration files and scripts
    test:     Add or update tests
    docs:     Update documentation (e.g., README)
    refactor: Code changes that neither fix a bug nor add a feature
    style:    modify CSS styles
-->

### Related Issue

- Please specify the issue number linked to this PR. (e.g., Fixes #<issue_number>)

### Description

- This PR improves the extraction and mapping logic for STOMP endpoint definitions in the WebSocket API analyzer.

- Updated EndpointUtil.extractStringArray to support multiple keys and return the first matched string(s).
- Enhanced toEndpoints logic to:
- Generate both SUBSCRIBE and corresponding UNSUBSCRIBE endpoints for each send destination.

### Testing

- Verified with annotated controller methods using @MessageMapping, @SendTo, and @SendToUser.
- Confirmed that endpoints are correctly generated for:

SEND (via @MessageMapping)
SUBSCRIBE (via @SendTo, @SendToUser)
UNSUBSCRIBE (inferred for each SUBSCRIBE path)

### Additional Notes

- The UNSUBSCRIBE endpoints are inferred and not explicitly declared in controller classes.

### Pre-Submission Checklist

- [x] Have you completed code style (convention) checks locally?
- [x] Have you passed the CI tests in your local environment?

